### PR TITLE
 ci: Fix buildroot to use new official image

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    container: quay.io/cgwalters/fcos-buildroot
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
 
     steps:
     - uses: actions/checkout@v2

--- a/src/.gitattributes
+++ b/src/.gitattributes
@@ -1,0 +1,1 @@
+auto/** linguist-generated=true


### PR DESCRIPTION
Mark src/auto/* as generated

---

ci: Fix buildroot to use new official image

Which is maintained and has updated rust.

---

