### PR TITLE
lib: fix 'dox' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
-name = "ostree"
-version = "0.12.0"
 authors = ["Felix Krull"]
-edition = "2018"
-
-license = "MIT"
 description = "Rust bindings for libostree"
+documentation = "https://docs.rs/ostree"
+edition = "2018"
 keywords = ["ostree", "libostree"]
-
-documentation = "https://fkrull.gitlab.io/ostree-rs/ostree"
-repository = "https://gitlab.com/fkrull/ostree-rs"
+license = "MIT"
+name = "ostree"
 readme = "README.md"
+repository = "https://github.com/ostreedev/ostree-rs"
+version = "0.12.0"
 
 exclude = [
     "conf/**",
@@ -23,9 +21,6 @@ exclude = [
 [package.metadata.docs.rs]
 features = ["dox"]
 
-[badges.gitlab]
-repository = "fkrull/ostree-rs"
-
 [lib]
 name = "ostree"
 
@@ -33,17 +28,17 @@ name = "ostree"
 members = [".", "sys"]
 
 [dependencies]
-libc = "0.2"
 bitflags = "1.2.1"
-glib = "0.14.0"
+ffi = { package = "ostree-sys", path = "sys", version = "0.8.0" }
 gio = "0.14.0"
+gio-sys = "0.14.0"
+glib = "0.14.0"
 glib-sys = "0.14.0"
 gobject-sys = "0.14.0"
-gio-sys = "0.14.0"
-once_cell = "1.4.0"
-ffi = { package = "ostree-sys", path = "sys", version = "0.8.0" }
-radix64 = "0.6.2"
 hex = "0.4.2"
+libc = "0.2"
+once_cell = "1.4.0"
+radix64 = "0.6.2"
 thiserror = "1.0.20"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! tools that combines a "git-like" model for committing and downloading bootable filesystem trees,
 //! along with a layer for deploying them and managing the bootloader configuration.
 
-#![doc(html_root_url = "https://fkrull.gitlab.io/ostree-rs")]
+#![cfg_attr(feature = "dox", feature(doc_cfg))]
 
 // Re-export our dependencies.  See https://gtk-rs.org/blog/2021/06/22/new-release.html
 // "Dependencies are re-exported".  Users will need e.g. `gio::File`, so this avoids


### PR DESCRIPTION
This makes sure docs can be properly built when using the 'dox'
feature. It should fix auto-builds on docs.rs.
It also touches Cargo manifest in order to update stale URLs,
pointing to the auto-built docpages at docs.rs and sorting entries.