### PR TITLE
ostree: release 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "ostree"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs"
-version = "0.12.0"
+version = "0.12.1"
 
 exclude = [
     "conf/**",


### PR DESCRIPTION
Changes:
 * cargoAdd 2021.3 feature
 * cargo: fix version in features chain
 * lib: fix 'dox' feature
 * lib: re-export glib, gio
