### PR TITLE
cargo: bump ostree-sys to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [".", "sys"]
 
 [dependencies]
 bitflags = "1.2.1"
-ffi = { package = "ostree-sys", path = "sys", version = "0.8.0" }
+ffi = { package = "ostree-sys", path = "sys", version = "0.8.1" }
 gio = "0.14.0"
 gio-sys = "0.14.0"
 glib = "0.14.0"

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -71,7 +71,7 @@ license = "MIT"
 links = "ostree-1"
 name = "ostree-sys"
 repository = "https://gitlab.com/fkrull/ostree-rs"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Ref: https://github.com/ostreedev/ostree-rs/pull/16#issuecomment-891131660