### PR TITLE
Add new GLib 0.14 variant types for metadata types

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,0 +1,21 @@
+//! Hand written bindings for ostree-core.h
+
+use glib::VariantDict;
+
+/// The type of a commit object: `(a{sv}aya(say)sstayay)`
+pub type CommitVariantType = (
+    VariantDict,
+    Vec<u8>,
+    Vec<(String, Vec<u8>)>,
+    String,
+    String,
+    u64,
+    Vec<u8>,
+    Vec<u8>,
+);
+
+/// The type of a dirtree object: `(a(say)a(sayay))`
+pub type TreeVariantType = (Vec<(String, Vec<u8>)>, Vec<(String, Vec<u8>, Vec<u8>)>);
+
+/// The type of a directory metadata object: `(uuua(ayay))`
+pub type DirmetaVariantType = (u32, u32, u32, Vec<(Vec<u8>, Vec<u8>)>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ pub use crate::auto::*;
 // handwritten code
 mod checksum;
 pub use crate::checksum::*;
+mod core;
+pub use crate::core::*;
+
 #[cfg(any(feature = "v2018_6", feature = "dox"))]
 mod collection_ref;
 #[cfg(any(feature = "v2018_6", feature = "dox"))]

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -1,0 +1,13 @@
+use crate::util::*;
+use std::error::Error;
+
+#[test]
+fn variant_types() -> Result<(), Box<dyn Error>> {
+    let tr = TestRepo::new();
+    let commit_checksum = tr.test_commit("test");
+    let repo = &tr.repo;
+    let commit_v = repo.load_variant(ostree::ObjectType::Commit, commit_checksum.as_str())?;
+    let commit = commit_v.get::<ostree::CommitVariantType>().unwrap();
+    assert_eq!(commit.3, "Test Commit");
+    Ok(())
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,4 @@
+mod core;
 mod functions;
 mod repo;
 #[cfg(feature = "v2020_2")]


### PR DESCRIPTION
This way it's more convenient for downstream crates like ostree-rs-ext
to convert loaded variants.

TODO: Can we add a feature for the `gvariant` crate and expose via
that too?