### PR TITLE
Fix build with --features=v2021_3, use in CI by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --features=v2021_3
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --features=v2021_3

--- a/tests/sign/mod.rs
+++ b/tests/sign/mod.rs
@@ -1,18 +1,21 @@
-use gio::NONE_CANCELLABLE;
-use glib::{Bytes, Variant};
-use ostree::{prelude::*, Sign};
+use ostree::prelude::*;
+use ostree::{gio, glib};
 
 #[test]
 fn sign_api_should_work() {
-    let dummy_sign = Sign::get_by_name("dummy").unwrap();
-    assert_eq!(dummy_sign.get_name().unwrap(), "dummy");
+    let dummy_sign = ostree::Sign::by_name("dummy").unwrap();
+    assert_eq!(dummy_sign.name().unwrap(), "dummy");
 
-    let result = dummy_sign.data(&Bytes::from_static(b"1234"), NONE_CANCELLABLE);
+    let result = ostree::prelude::SignExt::data(
+        &dummy_sign,
+        &glib::Bytes::from_static(b"1234"),
+        gio::NONE_CANCELLABLE,
+    );
     assert!(result.is_err());
 
-    let result = dummy_sign.data_verify(&Bytes::from_static(b"1234"), &Variant::from("1234"));
+    let result = dummy_sign.data_verify(&glib::Bytes::from_static(b"1234"), &"1234".to_variant());
     assert!(result.is_err());
 
-    let result = Sign::get_by_name("NOPE");
+    let result = ostree::Sign::by_name("NOPE");
     assert!(result.is_err());
 }


### PR DESCRIPTION
It's a huge trap for us not to build with the latest ostree feature
on, I didn't have my IDE configured for it, and CI didn't have
it on.

The previous bump to glib 0.14 broke the Sign code.