### PR TITLE
Use glib-sys via re-exported `glib::ffi` (and similar for gio)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,9 +60,6 @@ pages:
   variables:
     RUSTDOCFLAGS: >-
       -Z unstable-options
-      --extern-html-root-url glib_sys=https://gtk-rs.org/docs
-      --extern-html-root-url gobject_sys=https://gtk-rs.org/docs
-      --extern-html-root-url gio_sys=https://gtk-rs.org/docs
       --extern-html-root-url glib=https://gtk-rs.org/docs
       --extern-html-root-url gio=https://gtk-rs.org/docs
   script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,8 @@ members = [".", "sys"]
 [dependencies]
 bitflags = "1.2.1"
 ffi = { package = "ostree-sys", path = "sys", version = "0.8.1" }
-gio = "0.14.0"
-gio-sys = "0.14.0"
-glib = "0.14.0"
-glib-sys = "0.14.0"
-gobject-sys = "0.14.0"
+gio = "0.14"
+glib = "0.14"
 hex = "0.4.2"
 libc = "0.2"
 once_cell = "1.4.0"

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,5 +1,5 @@
+use glib::ffi::{g_free, g_malloc0, gpointer};
 use glib::translate::{FromGlibPtrFull, FromGlibPtrNone};
-use glib_sys::{g_free, g_malloc0, gpointer};
 use once_cell::sync::OnceCell;
 use std::ptr::copy_nonoverlapping;
 
@@ -168,8 +168,8 @@ impl FromGlibPtrNone<*mut [u8; BYTES_LEN]> for Checksum {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use glib::ffi::g_malloc0;
     use glib::translate::from_glib_full;
-    use glib_sys::g_malloc0;
 
     const CHECKSUM_BYTES: &[u8; BYTES_LEN] = b"\xbf\x87S\x06x>\xfd\xc5\xbc\xab7\xea\x10\xb6\xcaN\x9bj\xea\x8b\x94X\r\x0c\xa9J\xf1 V\\\x0e\x8a";
     const CHECKSUM_HEX: &str = "bf875306783efdc5bcab37ea10b6ca4e9b6aea8b94580d0ca94af120565c0e8a";

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,8 +1,8 @@
 #[cfg(any(feature = "v2017_13", feature = "dox"))]
 use crate::ChecksumFlags;
 use crate::{Checksum, ObjectType};
+use glib::ffi::GFALSE;
 use glib::{prelude::*, translate::*};
-use glib_sys::GFALSE;
 use std::{future::Future, mem::MaybeUninit, pin::Pin, ptr};
 
 /// Compute the SHA-256 checksum of a file.
@@ -41,9 +41,9 @@ pub fn checksum_file_async<
     unsafe extern "C" fn checksum_file_async_trampoline<
         R: FnOnce(Result<Checksum, Box<dyn std::error::Error>>) + Send + 'static,
     >(
-        _source_object: *mut gobject_sys::GObject,
-        res: *mut gio_sys::GAsyncResult,
-        user_data: glib_sys::gpointer,
+        _source_object: *mut glib::gobject_ffi::GObject,
+        res: *mut gio::ffi::GAsyncResult,
+        user_data: glib::ffi::gpointer,
     ) {
         let mut error = ptr::null_mut();
         let mut out_csum = MaybeUninit::uninit();
@@ -145,7 +145,7 @@ pub fn checksum_file_at<P: IsA<gio::Cancellable>>(
 
 unsafe fn checksum_file_error(
     out_csum: *mut [*mut u8; 32],
-    error: *mut glib_sys::GError,
+    error: *mut glib::ffi::GError,
     ret: i32,
 ) -> Result<Checksum, Box<dyn std::error::Error>> {
     if !error.is_null() {

--- a/src/object_name.rs
+++ b/src/object_name.rs
@@ -3,7 +3,6 @@ use crate::{object_name_deserialize, object_name_serialize, object_to_string};
 use glib;
 use glib::translate::*;
 use glib::GString;
-use glib_sys;
 use std::fmt::Display;
 use std::fmt::Error;
 use std::fmt::Formatter;
@@ -11,7 +10,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 fn hash_object_name(v: &glib::Variant) -> u32 {
-    unsafe { ffi::ostree_hash_object_name(v.to_glib_none().0 as glib_sys::gconstpointer) }
+    unsafe { ffi::ostree_hash_object_name(v.to_glib_none().0 as glib::ffi::gconstpointer) }
 }
 
 /// A reference to an object in an OSTree repo. It contains both a checksum and an

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2,9 +2,8 @@
 use crate::RepoListRefsExtFlags;
 use crate::{Checksum, ObjectName, ObjectType, Repo};
 use ffi;
-use gio_sys;
+use glib::ffi as glib_sys;
 use glib::{self, translate::*, Error, IsA};
-use glib_sys;
 use std::{
     collections::{HashMap, HashSet},
     future::Future,
@@ -193,9 +192,9 @@ impl Repo {
         unsafe extern "C" fn write_content_async_trampoline<
             R: FnOnce(Result<Checksum, Error>) + Send + 'static,
         >(
-            _source_object: *mut gobject_sys::GObject,
-            res: *mut gio_sys::GAsyncResult,
-            user_data: glib_sys::gpointer,
+            _source_object: *mut glib::gobject_ffi::GObject,
+            res: *mut gio::ffi::GAsyncResult,
+            user_data: glib::ffi::gpointer,
         ) {
             let mut error = ptr::null_mut();
             let mut out_csum = MaybeUninit::uninit();
@@ -268,8 +267,8 @@ impl Repo {
         unsafe extern "C" fn write_metadata_async_trampoline<
             Q: FnOnce(Result<Checksum, Error>) + Send + 'static,
         >(
-            _source_object: *mut gobject_sys::GObject,
-            res: *mut gio_sys::GAsyncResult,
+            _source_object: *mut glib::gobject_ffi::GObject,
+            res: *mut gio::ffi::GAsyncResult,
             user_data: glib_sys::gpointer,
         ) {
             let mut error = ptr::null_mut();

--- a/src/repo_checkout_at_options/mod.rs
+++ b/src/repo_checkout_at_options/mod.rs
@@ -166,7 +166,7 @@ impl<'a> ToGlibPtr<'a, *const ffi::OstreeRepoCheckoutAtOptions> for RepoCheckout
 #[cfg(test)]
 mod tests {
     use super::*;
-    use glib_sys::{GFALSE, GTRUE};
+    use glib::ffi::{GFALSE, GTRUE};
     use std::ffi::{CStr, CString};
     use std::ptr;
 

--- a/src/repo_checkout_at_options/repo_checkout_filter.rs
+++ b/src/repo_checkout_at_options/repo_checkout_filter.rs
@@ -1,6 +1,6 @@
 use crate::{Repo, RepoCheckoutFilterResult};
+use glib::ffi::gpointer;
 use glib::translate::*;
-use glib_sys::gpointer;
 use libc::c_char;
 use std::any::Any;
 use std::panic::catch_unwind;

--- a/src/repo_transaction_stats.rs
+++ b/src/repo_transaction_stats.rs
@@ -1,13 +1,11 @@
-use gobject_sys;
-
 glib::wrapper! {
     /// A list of statistics for each transaction that may be interesting for reporting purposes.
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct RepoTransactionStats(Boxed<ffi::OstreeRepoTransactionStats>);
 
     match fn {
-        copy => |ptr| gobject_sys::g_boxed_copy(ffi::ostree_repo_transaction_stats_get_type(), ptr as *mut _) as *mut ffi::OstreeRepoTransactionStats,
-        free => |ptr| gobject_sys::g_boxed_free(ffi::ostree_repo_transaction_stats_get_type(), ptr as *mut _),
+        copy => |ptr| glib::gobject_ffi::g_boxed_copy(ffi::ostree_repo_transaction_stats_get_type(), ptr as *mut _) as *mut ffi::OstreeRepoTransactionStats,
+        free => |ptr| glib::gobject_ffi::g_boxed_free(ffi::ostree_repo_transaction_stats_get_type(), ptr as *mut _),
         init => |_ptr| (),
         clear => |_ptr| (),
         type_ => || ffi::ostree_repo_transaction_stats_get_type(),

--- a/src/sysroot_write_deployments_opts.rs
+++ b/src/sysroot_write_deployments_opts.rs
@@ -33,7 +33,7 @@ impl<'a> ToGlibPtr<'a, *const OstreeSysrootWriteDeploymentsOpts> for SysrootWrit
 #[cfg(test)]
 mod tests {
     use super::*;
-    use glib_sys::{GFALSE, GTRUE};
+    use glib::ffi::{GFALSE, GTRUE};
 
     #[test]
     fn should_convert_default_options() {

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -5,9 +5,9 @@ repository = "fkrull/ostree-rs"
 system-deps = "3"
 
 [dependencies]
-glib-sys = "0.14.0"
-gobject-sys = "0.14.0"
-gio-sys = "0.14.0"
+glib-sys = "0.14"
+gobject-sys = "0.14"
+gio-sys = "0.14"
 libc = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION


In general only `-sys` crates should depend on other `-sys`
crates.  IOW for us, `ostree-sys` depends on `glib-sys`.

By using the re-export, we avoid needing to keep a version lock
between `glib` and `glib-sys` in our main crate.  And similar
is true of our higher level reverse dependencies (e.g. `ostree-rs-ext`).

Also weaken our dependency to `0.14` as that's clearer.

---

