### PR TITLE
prelude: Also export `glib` and `gio`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,10 @@ mod tests;
 pub mod prelude {
     pub use crate::auto::traits::*;
     // See "Re-export dependencies above".
+    pub use gio;
     #[doc(hidden)]
     pub use gio::prelude::*;
+    pub use glib;
     #[doc(hidden)]
     pub use glib::prelude::*;
 }

--- a/tests/sign/mod.rs
+++ b/tests/sign/mod.rs
@@ -1,5 +1,4 @@
 use ostree::prelude::*;
-use ostree::{gio, glib};
 
 #[test]
 fn sign_api_should_work() {

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,6 +1,6 @@
 use gio::NONE_CANCELLABLE;
-use glib::prelude::*;
 use glib::GString;
+use ostree::prelude::*;
 use std::path::Path;
 
 #[derive(Debug)]


### PR DESCRIPTION
This is a followup to "Dependencies are re-exported" from
https://gtk-rs.org/blog/2021/06/22/new-release.html
that we tried to follow in https://github.com/ostreedev/ostree-rs/pull/13

But now I'm trying to change `ostree-rs-ext` to be able to just do
`import ostree::prelude::*;` and be able to use e.g. `gio::Cancellable`,
but that didn't work without this explicit import of the toplevel
items too.