### PR TITLE
Release 0.12.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "ostree"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs"
-version = "0.12.1"
+version = "0.12.2"
 
 exclude = [
     "conf/**",

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -71,7 +71,7 @@ license = "MIT"
 links = "ostree-1"
 name = "ostree-sys"
 repository = "https://gitlab.com/fkrull/ostree-rs"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2018"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
```
Colin Walters (8):
      Add 2021.3 feature
      Re-export glib, gio
      Deny unused results, warn on missing docs (except auto/)
      Add new GLib 0.14 variant types for metadata types
      Fix build with --features=v2021_3, use in CI by default
      Add more documentation for --features=v2021_3
      Use glib-sys via re-exported `glib::ffi` (and similar for gio)
```