### PR TITLE
lib: Export ffi too

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 // Re-export our dependencies.  See https://gtk-rs.org/blog/2021/06/22/new-release.html
 // "Dependencies are re-exported".  Users will need e.g. `gio::File`, so this avoids
 // them needing to update matching versions.
+pub use ffi;
 pub use gio;
 pub use glib;
 


### PR DESCRIPTION
Matching how gtk-rs does it.  Right now rpm-ostree does depend
on interacting with `ostree-sys` via the cxxrs bits.