### PR TITLE
Make `SePolicy` have `Send`

### DIFF
--- a/conf/ostree.toml
+++ b/conf/ostree.toml
@@ -192,6 +192,7 @@ status = "generate"
 [[object]]
 name = "OSTree.SePolicy"
 status = "generate"
+concurrency = "send"
     [[object.function]]
     # [IGNORE] has an unused raw pointer parameter
     name = "fscreatecon_cleanup"

--- a/src/auto/se_policy.rs
+++ b/src/auto/se_policy.rs
@@ -106,6 +106,8 @@ impl SePolicy {
     }
 }
 
+unsafe impl Send for SePolicy {}
+
 impl fmt::Display for SePolicy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("SePolicy")


### PR DESCRIPTION
It's safe to send between threads, and I want to do so
in ostree-rs-ext to send to a tokio worker thread.