### PR TITLE
repo: Add `require_rev` method

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -175,6 +175,13 @@ impl Repo {
         }
     }
 
+    /// Resolve a refspec to a commit SHA256.
+    /// Returns an error if the refspec does not exist.
+    pub fn require_rev(&self, refspec: &str) -> Result<glib::GString, Error> {
+        // SAFETY: Since we said `false` for "allow_noent", this function must return a value
+        Ok(self.resolve_rev(refspec, false)?.unwrap())
+    }
+
     /// Write a content object from provided input.
     pub fn write_content<P: IsA<gio::InputStream>, Q: IsA<gio::Cancellable>>(
         &self,

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -10,8 +10,12 @@ mod checkout_at;
 fn should_commit_content_to_repo_and_list_refs_again() {
     let test_repo = TestRepo::new();
 
+    assert!(test_repo.repo.require_rev("nosuchrev").is_err());
+
     let mtree = create_mtree(&test_repo.repo);
     let checksum = commit(&test_repo.repo, &mtree, "test");
+
+    assert_eq!(test_repo.repo.require_rev("test").unwrap(), checksum);
 
     let repo = ostree::Repo::new_for_path(test_repo.dir.path());
     repo.open(NONE_CANCELLABLE).expect("OSTree test_repo");


### PR DESCRIPTION
The `resolve_rev` C method should really have been
`resolve_rev_optional` from the start - it is more obviously wrong
in Rust because the input parameter `allows_noent` controls
whether the returned `Option` can ever be `None`.

I debated adding this to the C bindings, and may still do so,
but eh it's faster to write + ship in Rust, and the future of ostree is
Rust anyways.