### PR TITLE
ci: add jobs for MSRV checks and linting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  actions: read
+
 on:
   push:
     branches: [ main ]
@@ -8,16 +11,58 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_PROJECT_FEATURES: "v2021_3"
+  # Minimum supported Rust version (MSRV)
+  ACTION_MSRV_TOOLCHAIN: 1.54.0
+  # Pinned toolchain for linting
+  ACTION_LINTS_TOOLCHAIN: 1.56.0
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose --features=v2021_3
-    - name: Run tests
-      run: cargo test --verbose --features=v2021_3
+      - uses: actions/checkout@v2
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      - name: Build
+        run: cargo build --verbose --features=${{ env['CARGO_PROJECT_FEATURES'] }}
+      - name: Run tests
+        run: cargo test --verbose --features=${{ env['CARGO_PROJECT_FEATURES'] }}
+  build-minimum-toolchain:
+    name: "Build, minimum supported toolchain (MSRV)"
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Remove system Rust toolchain
+        run: dnf remove -y rust cargo
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          default: true
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      - name: cargo build
+        run: cargo build --features=${{ env['CARGO_PROJECT_FEATURES'] }}
+  linting:
+    name: "Lints, pinned toolchain"
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Remove system Rust toolchain
+        run: dnf remove -y rust cargo
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
+          default: true
+          components: rustfmt, clippy
+      - name: cargo fmt (check)
+        run: cargo fmt -p ostree -- --check -l
+      - name: cargo clippy (warnings)
+        run: cargo clippy -p ostree --features=${{ env['CARGO_PROJECT_FEATURES'] }} -- -D warnings

--- a/src/kernel_args.rs
+++ b/src/kernel_args.rs
@@ -1,7 +1,5 @@
 use ffi::OstreeKernelArgs;
 #[cfg(any(feature = "v2019_3", feature = "dox"))]
-use gio;
-#[cfg(any(feature = "v2019_3", feature = "dox"))]
 use glib::object::IsA;
 use glib::translate::*;
 #[cfg(any(feature = "v2019_3", feature = "dox"))]

--- a/src/object_details.rs
+++ b/src/object_details.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
-use std::fmt::Formatter;
 use std::fmt::Error;
+use std::fmt::Formatter;
 
 /// Details of an object in an OSTree repo. It contains information about if
 /// the object is "loose", and contains a list of pack file checksums in which
@@ -32,11 +32,13 @@ impl ObjectDetails {
     }
 }
 
-impl Display for ObjectDetails{
+impl Display for ObjectDetails {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "Object is {} and appears in {} checksums",
-                if self.loose {"loose"} else {"not loose"},
-                self.object_appearances.len() )
+        write!(
+            f,
+            "Object is {} and appears in {} checksums",
+            if self.loose { "loose" } else { "not loose" },
+            self.object_appearances.len()
+        )
     }
 }
-

--- a/src/object_details.rs
+++ b/src/object_details.rs
@@ -1,4 +1,3 @@
-use glib;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Error;

--- a/src/object_name.rs
+++ b/src/object_name.rs
@@ -1,6 +1,5 @@
 use crate::ObjectType;
 use crate::{object_name_deserialize, object_name_serialize, object_to_string};
-use glib;
 use glib::translate::*;
 use glib::GString;
 use std::fmt::Display;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,7 +1,6 @@
 #[cfg(any(feature = "v2016_4", feature = "dox"))]
 use crate::RepoListRefsExtFlags;
 use crate::{Checksum, ObjectName, ObjectDetails, ObjectType, Repo, RepoTransactionStats};
-use ffi;
 use ffi::OstreeRepoListObjectsFlags;
 use glib::ffi as glib_sys;
 use glib::{self, translate::*, Error, IsA};
@@ -117,7 +116,7 @@ impl Repo {
             let copy = dfd.try_clone();
             // Now release our temporary ownership of the original
             let _ = dfd.into_raw_fd();
-            Ok(copy?)
+            copy
         }
     }
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,6 +1,6 @@
 #[cfg(any(feature = "v2016_4", feature = "dox"))]
 use crate::RepoListRefsExtFlags;
-use crate::{Checksum, ObjectName, ObjectDetails, ObjectType, Repo, RepoTransactionStats};
+use crate::{Checksum, ObjectDetails, ObjectName, ObjectType, Repo, RepoTransactionStats};
 use ffi::OstreeRepoListObjectsFlags;
 use glib::ffi as glib_sys;
 use glib::{self, translate::*, Error, IsA};
@@ -30,7 +30,8 @@ unsafe extern "C" fn read_variant_object_map(
 ) {
     let key: glib::Variant = from_glib_none(key as *const glib_sys::GVariant);
     let value: glib::Variant = from_glib_none(value as *const glib_sys::GVariant);
-    let set: &mut HashMap<ObjectName, ObjectDetails> = &mut *(hash_set as *mut HashMap<ObjectName, ObjectDetails>);
+    let set: &mut HashMap<ObjectName, ObjectDetails> =
+        &mut *(hash_set as *mut HashMap<ObjectName, ObjectDetails>);
     if let Some(details) = ObjectDetails::new_from_variant(value) {
         set.insert(ObjectName::new_from_variant(key), details);
     }
@@ -47,7 +48,9 @@ unsafe fn from_glib_container_variant_set(ptr: *mut glib_sys::GHashTable) -> Has
     set
 }
 
-unsafe fn from_glib_container_variant_map(ptr: *mut glib_sys::GHashTable) -> HashMap<ObjectName, ObjectDetails> {
+unsafe fn from_glib_container_variant_map(
+    ptr: *mut glib_sys::GHashTable,
+) -> HashMap<ObjectName, ObjectDetails> {
     let mut set = HashMap::new();
     glib_sys::g_hash_table_foreach(
         ptr,
@@ -186,7 +189,7 @@ impl Repo {
                 flags,
                 &mut hashtable,
                 cancellable.map(AsRef::as_ref).to_glib_none().0,
-                &mut error
+                &mut error,
             );
 
             if error.is_null() {

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -49,7 +49,7 @@ impl SysrootBuilder {
     /// Perform common configuration steps, returning a not-yet-fully-loaded `Sysroot`.
     fn configure_common(self) -> Sysroot {
         let sysroot = {
-            let opt_file = self.path.map(|p| gio::File::for_path(p));
+            let opt_file = self.path.map(gio::File::for_path);
             Sysroot::new(opt_file.as_ref())
         };
 

--- a/tests/functions/mod.rs
+++ b/tests/functions/mod.rs
@@ -11,17 +11,28 @@ fn list_repo_objects() {
     let mut file_cnt = 0;
     let mut commit_cnt = 0;
 
-    let objects = repo.repo.list_objects( ffi::OSTREE_REPO_LIST_OBJECTS_ALL, NONE_CANCELLABLE).expect("List Objects");
+    let objects = repo
+        .repo
+        .list_objects(ffi::OSTREE_REPO_LIST_OBJECTS_ALL, NONE_CANCELLABLE)
+        .expect("List Objects");
     for (object, _items) in objects {
-        match object.object_type()  {
-            ObjectType::DirTree => { dirtree_cnt += 1; },
-            ObjectType::DirMeta => { dirmeta_cnt += 1; },
-            ObjectType::File => { file_cnt += 1; },
+        match object.object_type() {
+            ObjectType::DirTree => {
+                dirtree_cnt += 1;
+            }
+            ObjectType::DirMeta => {
+                dirmeta_cnt += 1;
+            }
+            ObjectType::File => {
+                file_cnt += 1;
+            }
             ObjectType::Commit => {
                 assert_eq!(commit_checksum.to_string(), object.checksum());
                 commit_cnt += 1;
-            },
-            x => { panic!("unexpected object type {}", x ); }
+            }
+            x => {
+                panic!("unexpected object type {}", x);
+            }
         }
     }
     assert_eq!(dirtree_cnt, 2);


### PR DESCRIPTION
This adds two jobs in order to check minimum toolchain compatibility,
and for overall linting.
Before getting there, it also fixes all the existing clippy warnings and rustfmt
the whole project.