### PR TITLE
repo: Add two more cap-std APIs

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -145,6 +145,18 @@ impl Repo {
         }
     }
 
+    /// Borrow the directory file descriptor for this repository.
+    #[cfg(feature = "cap-std-apis")]
+    pub fn dfd_borrow<'a>(&'a self) -> io_lifetimes::BorrowedFd<'a> {
+        unsafe { io_lifetimes::BorrowedFd::borrow_raw_fd(self.dfd()) }
+    }
+
+    /// Return a new `cap-std` directory reference for this repository.
+    #[cfg(feature = "cap-std-apis")]
+    pub fn dfd_as_dir(&self) -> std::io::Result<cap_std::fs::Dir> {
+        cap_std::fs::Dir::reopen_dir(&self.dfd_borrow())
+    }
+
     /// Find all objects reachable from a commit.
     pub fn traverse_commit<P: IsA<gio::Cancellable>>(
         &self,

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -31,6 +31,10 @@ fn should_commit_content_to_repo_and_list_refs_again() {
 fn cap_std_commit() {
     let test_repo = CapTestRepo::new();
 
+    assert!(test_repo.dir.exists("config"));
+    // Also test re-acquiring a new dfd
+    assert!(test_repo.repo.dfd_as_dir().unwrap().exists("config"));
+
     assert!(test_repo.repo.require_rev("nosuchrev").is_err());
 
     let mtree = create_mtree(&test_repo.repo);


### PR DESCRIPTION
Followup to the previous PR.  I realized now with `io_lifetimes`
we can offer a safe `dfd_borrow()` that *borrows* the file descriptor
for the repository.  (In contrast to the current `.dfd()` that returns
the raw version)

Building on that, add another API that re-acquires a `Dir` instance.
(In the future in theory we could optimize this more by knowing
 whether or not the repo was constructed via cap-std, and perhaps
 in theory synthesize a `&Dir` reference, but I don't think we
 need that now)