### PR TITLE
Add `COMMIT_META_CONTAINER_CMD` constant

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,3 @@
+/// Metadata key corresponding to the Docker/OCI `CMD` verb.
+/// <https://github.com/opencontainers/image-spec/blob/main/config.md>
+pub const COMMIT_META_CONTAINER_CMD: &str = "ostree.container-cmd";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ pub use crate::core::*;
 mod sysroot;
 pub use crate::sysroot::*;
 
+mod constants;
+pub use constants::*;
+
 #[cfg(any(feature = "v2018_6", feature = "dox"))]
 mod collection_ref;
 #[cfg(any(feature = "v2018_6", feature = "dox"))]


### PR DESCRIPTION
Today we hardcode `/bin/bash` in
https://github.com/coreos/coreos-assembler/blob/2088d24884771093101d95f915c921505128ef76/src/cmd-build#L405

But that breaks the concept of a bidirectional bridge between
container image and ostree commit because this little bit of
knowledge is encoded at the buildsystem side.

This metadata key is intended to be written into an ostree commit,
and then we will use it automatically in `container encapsulate`.

The "source of truth" for this key will hence be able live in the same
place that's generating the ostree commit.

The more "proper" place for this is probably alongside the other
constants in the libostree core C code.  But that's tedious and
slow to release.  And Rust is the future.  And we've been slowly
adding more "core ostree" functionality here.