### PR TITLE
Fast-track fix for `ostree_gpg_verify_result_get_all()`

### DIFF
--- a/src/auto/gpg_verify_result.rs
+++ b/src/auto/gpg_verify_result.rs
@@ -50,7 +50,7 @@ impl GpgVerifyResult {
     #[doc(alias = "get_all")]
     pub fn all(&self, signature_index: u32) -> Option<glib::Variant> {
         unsafe {
-            from_glib_full(ffi::ostree_gpg_verify_result_get_all(self.to_glib_none().0, signature_index))
+            from_glib_none(ffi::ostree_gpg_verify_result_get_all(self.to_glib_none().0, signature_index))
         }
     }
 


### PR DESCRIPTION
This cherry picks just the changes from
https://github.com/ostreedev/ostree/pull/2537

We don't need to wait to respin a new ostree release just
for this.