### PR TITLE
Add manual bindings for MutableTree reading

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ mod collection_ref;
 pub use crate::collection_ref::*;
 mod functions;
 pub use crate::functions::*;
+mod mutable_tree;
+pub use crate::mutable_tree::*;
 #[cfg(any(feature = "v2019_3", feature = "dox"))]
 mod kernel_args;
 #[cfg(any(feature = "v2019_3", feature = "dox"))]

--- a/src/mutable_tree.rs
+++ b/src/mutable_tree.rs
@@ -1,0 +1,46 @@
+use crate::MutableTree;
+use glib::{self, translate::*};
+use std::collections::HashMap;
+
+impl MutableTree {
+    #[doc(alias = "ostree_mutable_tree_get_files")]
+    /// Create a copy of the files in this mutable tree.
+    /// Unlike the C version of this function, a copy is made because providing
+    /// read-write access would introduce the potential for use-after-free bugs.
+    pub fn copy_files(&self) -> HashMap<String, String> {
+        unsafe {
+            let v = ffi::ostree_mutable_tree_get_files(self.to_glib_none().0);
+            HashMap::from_glib_none_num(v, 1)
+        }
+    }
+
+    #[doc(alias = "ostree_mutable_tree_get_subdirs")]
+    /// Create a copy of the directories in this mutable tree.
+    /// Unlike the C version of this function, a copy is made because providing
+    /// read-write access would introduce the potential for use-after-free bugs.
+    pub fn copy_subdirs(&self) -> HashMap<String, Self> {
+        use glib::ffi::gpointer;
+
+        unsafe {
+            let v = ffi::ostree_mutable_tree_get_subdirs(self.to_glib_none().0);
+            unsafe extern "C" fn visit_hash_table(
+                key: gpointer,
+                value: gpointer,
+                hash_map: gpointer,
+            ) {
+                let key: String = from_glib_none(key as *const libc::c_char);
+                let value: MutableTree = from_glib_none(value as *const ffi::OstreeMutableTree);
+                let hash_map: &mut HashMap<String, MutableTree> =
+                    &mut *(hash_map as *mut HashMap<String, MutableTree>);
+                hash_map.insert(key, value);
+            }
+            let mut map = HashMap::with_capacity(glib::ffi::g_hash_table_size(v) as usize);
+            glib::ffi::g_hash_table_foreach(
+                v,
+                Some(visit_hash_table),
+                &mut map as *mut HashMap<String, MutableTree> as *mut _,
+            );
+            map
+        }
+    }
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -50,6 +50,8 @@ impl CapTestRepo {
 
 pub fn create_mtree(repo: &ostree::Repo) -> ostree::MutableTree {
     let mtree = ostree::MutableTree::new();
+    assert_eq!(mtree.copy_files().len(), 0);
+    assert_eq!(mtree.copy_subdirs().len(), 0);
     let file = gio::File::for_path(
         Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests")


### PR DESCRIPTION
I'm trying to debug a problem in ostree-rs-ext, and it's
handy to be able to do `dbg!(mtree.copy_files())`.