### PR TITLE
repo: Add `query_file` API

### DIFF
--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -89,6 +89,15 @@ fn repo_traverse_and_read() {
         .unwrap();
     // Right now, the uid/gid are actually that of the test runner
     assert_eq!(dirmeta.mode, 0o40750);
+
+    let (finfo, _xattrs) = test_repo
+        .repo
+        .query_file(
+            "89f84ca9854a80e85b583e46a115ba4985254437027bad34f0b113219323d3f8",
+            NONE_CANCELLABLE,
+        )
+        .unwrap();
+    assert_eq!(finfo.size(), 5);
 }
 
 #[test]


### PR DESCRIPTION
The underlying `ostree_repo_load_file()` API has the caller pass
`NULL` for output arguments it doesn't want.  This isn't sanely
bindable in Rust - what the generator does is always request
all values, but maps them all to `Option<T>`.

The main cases are where a user wants either metadata, or both
metadata and content.  This API gives just metadata; it's a
bit more efficient as we don't need to open the file, and doesn't
require the caller to `unwrap()`.