### PR TITLE
Add a `repo()` accessor to `TransactionGuard`

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -72,6 +72,12 @@ pub struct TransactionGuard<'a> {
 }
 
 impl<'a> TransactionGuard<'a> {
+    /// Returns a reference to the repository.
+    pub fn repo(&self) -> &Repo {
+        // SAFETY: This is only set to None in `commit`, which consumes self
+        self.repo.unwrap()
+    }
+
     /// Commit this transaction.
     pub fn commit<P: IsA<gio::Cancellable>>(
         mut self,

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -67,7 +67,8 @@ pub fn commit(repo: &ostree::Repo, mtree: &ostree::MutableTree, ref_: &str) -> G
     let txn = repo
         .auto_transaction(NONE_CANCELLABLE)
         .expect("prepare transaction");
-    let repo_file = repo
+    let repo_file = txn
+        .repo()
         .write_mtree(mtree, NONE_CANCELLABLE)
         .expect("write mtree")
         .downcast::<ostree::RepoFile>()


### PR DESCRIPTION
I want to write APIs that *require* the caller to have set up
an ostree transaction.  It's natural to require passing a guard
to do so.  But then we want an accessor for the repo.